### PR TITLE
Support of i2c PCA9557 expander

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -36,3 +36,4 @@ ContinuationIndentWidth: 4
 UseTab: Never
 IndentPPDirectives: BeforeHash
 ...
+#EOF

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ HAL for GPIOs
 #define OPENKNX_GPIO_NUM 1
 #define OPENKNX_GPIO_TYPES OPENKNX_GPIO_T_TCA9555
 #define OPENKNX_GPIO_ADDRS 0x20
-#define OPENKNX_GPIO_INTS 0xFF
+#define OPENKNX_GPIO_INTS 0xFF  
 
 #define OPENKNX_GPIO_WIRE Wire
 #define OPENKNX_GPIO_CLOCK 400000
@@ -26,7 +26,13 @@ openknx.addModule(4, openknxGPIOModule);
 ..
 openknxGPIOModule.pinMode(24, OUTPUT);      // set MCU-GPIO 24 to OUTPUT
 openknxGPIOModule.digitalWrite(24, HIGH);   // writes MCU-GPIO 24 to HIGH
-openknxGPIOModule.digitalRead(0x0105);      // reads GPIO 5 of expander 0x01
+
+if (openknxGPIOModule.initialized(1))           // check the initialized state of the expander 0x01
+{
+  openknxGPIOModule.pinMode(0x0105, OUTPUT);    // sets the GPIO 5 to OUTPUT expander 0x01.
+  openknxGPIOModule.digitalWrite(0x0105, HIGH); // writes digital value HIGH to GPIO 5 of the expander 0x01
+}
+ openknxGPIOModule.digitalRead(0x0105);         // reads GPIO 5 of expander 0x01.
 ```
 
 # Supported HW
@@ -36,6 +42,8 @@ RP2040 (single core)
 wraps the `pinMode`, `digitalWrite`, ... functions
 ## TCA9555
 TCA9555 16bit I2C port expander
+## PCA9557
+PCA9557 8-bit I2C-bus expander (I2C slave address range 0x18 to 0x1F )
 
 
 # Features

--- a/library.json
+++ b/library.json
@@ -2,7 +2,8 @@
     "name": "OFM-GPIOModule",
     "version": "0.0.0",
     "dependencies": {
-        "robtillaart/TCA9555": "^0.3.2"
+        "robtillaart/TCA9555": "^0.3.2", 
+        "sparkfun/SparkFun I2C Expander Arduino Library":"^1.0.1"
     },
     "description": "Hardware abstraction layer for GPIOs",
     "homepage": "https://openknx.de",

--- a/library.json
+++ b/library.json
@@ -2,8 +2,7 @@
     "name": "OFM-GPIOModule",
     "version": "0.0.0",
     "dependencies": {
-        "robtillaart/TCA9555": "^0.3.2", 
-        "sparkfun/SparkFun I2C Expander Arduino Library":"^1.0.1"
+        "robtillaart/TCA9555": "^0.3.2"
     },
     "description": "Hardware abstraction layer for GPIOs",
     "homepage": "https://openknx.de",

--- a/src/GPIOModule.cpp
+++ b/src/GPIOModule.cpp
@@ -26,8 +26,7 @@ const std::string GPIOModule::name()
 
 const std::string GPIOModule::version()
 {
-    //ToDo
-    return 0;
+    return MODULE_GPIOModule_Version;
 }
 
 

--- a/src/GPIOModule.cpp
+++ b/src/GPIOModule.cpp
@@ -1,16 +1,17 @@
+#ifdef USE_GPIO_MODULE
 #include "GPIOModule.h"
-#include "OpenKNX.h"
-#include "GPIO_TCA9555.h"
-#include "GPIO_TCA6408.h"
 #include "GPIO_MCU.h"
 #include "GPIO_PCA9557.h"
+#include "GPIO_TCA6408.h"
+#include "GPIO_TCA9555.h"
+#include "OpenKNX.h"
 
 GPIOModule openknxGPIOModule;
 
-const OPENKNX_GPIO_T GPIO_TYPES[OPENKNX_GPIO_NUM+1] = {OPENKNX_GPIO_T_MCU, OPENKNX_GPIO_TYPES};
-const uint16_t GPIO_ADDRS[OPENKNX_GPIO_NUM+1] = {0, OPENKNX_GPIO_ADDRS};
-const uint8_t GPIO_INTS[OPENKNX_GPIO_NUM+1] = {0, OPENKNX_GPIO_INTS};
-iGPIOExpander* GPIOExpanders[OPENKNX_GPIO_NUM+1];
+const OPENKNX_GPIO_T GPIO_TYPES[OPENKNX_GPIO_NUM + 1] = {OPENKNX_GPIO_T_MCU, OPENKNX_GPIO_TYPES};
+const uint16_t GPIO_ADDRS[OPENKNX_GPIO_NUM + 1] = {0, OPENKNX_GPIO_ADDRS};
+const uint8_t GPIO_INTS[OPENKNX_GPIO_NUM + 1] = {0, OPENKNX_GPIO_INTS};
+iGPIOExpander* GPIOExpanders[OPENKNX_GPIO_NUM + 1];
 
 GPIOModule::GPIOModule()
 {
@@ -30,18 +31,21 @@ const std::string GPIOModule::version()
     return MODULE_GPIOModule_Version;
 }
 
-
-
 void GPIOModule::init()
 {
+#ifdef ARDUINO_ARCH_RP2040
     OPENKNX_GPIO_WIRE.setSDA(OPENKNX_GPIO_SDA);
     OPENKNX_GPIO_WIRE.setSCL(OPENKNX_GPIO_SCL);
     OPENKNX_GPIO_WIRE.begin();
     OPENKNX_GPIO_WIRE.setClock(OPENKNX_GPIO_CLOCK);
+#else
+    OPENKNX_GPIO_WIRE.begin(OPENKNX_GPIO_SDA, OPENKNX_GPIO_SCL, OPENKNX_GPIO_CLOCK );
+#endif
+   
 
-    for(int i = 0; i < OPENKNX_GPIO_NUM+1; i++)
+    for (int i = 0; i < OPENKNX_GPIO_NUM + 1; i++)
     {
-        switch(GPIO_TYPES[i])
+        switch (GPIO_TYPES[i])
         {
             case OPENKNX_GPIO_T_MCU:
             {
@@ -53,7 +57,7 @@ void GPIOModule::init()
             {
                 GPIOExpanders[i] = new GPIO_TCA9555(GPIO_ADDRS[i], &OPENKNX_GPIO_WIRE);
                 const int statuscode = GPIOExpanders[i]->init();
-                if(statuscode)
+                if (statuscode)
                 {
                     logErrorP("no connection to GPIO Expander %u with address %u (Errorcode: %u)", i, GPIO_ADDRS[i], statuscode);
                 }
@@ -68,7 +72,7 @@ void GPIOModule::init()
             {
                 GPIOExpanders[i] = new GPIO_TCA6408(GPIO_ADDRS[i], &OPENKNX_GPIO_WIRE);
                 const int statuscode = GPIOExpanders[i]->init();
-                if(statuscode)
+                if (statuscode)
                 {
                     logErrorP("no connection to GPIO Expander %u with address %u (Errorcode: %u)", i, GPIO_ADDRS[i], statuscode);
                 }
@@ -94,8 +98,7 @@ void GPIOModule::init()
                 }
             }
             break;
-            default:
-                ;
+            default:;
                 logErrorP("GPIO_TYPE %u not found", GPIO_TYPES[i]);
         }
     }
@@ -108,14 +111,13 @@ const bool GPIOModule::initialized(uint8_t expander)
 
 void GPIOModule::loop()
 {
-
 }
 
 void GPIOModule::pinMode(uint16_t pin, int mode, bool preset, int status)
 {
     int8_t localpin = pin & 0xff;
     uint8_t expander = pin >> 8;
-    if(expander > OPENKNX_GPIO_NUM)
+    if (expander > OPENKNX_GPIO_NUM)
     {
         logErrorP("GPIOModule::pinMode: invalid pin id %u", pin);
         return;
@@ -127,11 +129,11 @@ void GPIOModule::digitalWrite(uint16_t pin, int status)
 {
     int8_t localpin = pin & 0xff;
     uint8_t expander = pin >> 8;
-    if(expander > OPENKNX_GPIO_NUM)
+    if (expander > OPENKNX_GPIO_NUM)
     {
         logErrorP("GPIOModule::digitalWrite: invalid pin id %u", pin);
         return;
-    } 
+    }
     GPIOExpanders[expander]->GPIOdigitalWrite(localpin, status);
 }
 
@@ -139,11 +141,11 @@ bool GPIOModule::digitalRead(uint16_t pin)
 {
     int8_t localpin = pin & 0xff;
     uint8_t expander = pin >> 8;
-    if(expander > OPENKNX_GPIO_NUM)
+    if (expander > OPENKNX_GPIO_NUM)
     {
         logErrorP("GPIOModule::digitalRead: invalid pin id %u", pin);
         return 0;
     }
     return GPIOExpanders[expander]->GPIOdigitalRead(localpin);
 }
-
+#endif // USE_GPIO_MODULE

--- a/src/GPIOModule.h
+++ b/src/GPIOModule.h
@@ -12,6 +12,8 @@ class iGPIOExpander
 {
   public:
     virtual int init() = 0;
+    virtual void setInitState(const bool status) = 0;
+    virtual const bool getInitState() = 0;
     virtual void GPIOpinMode(uint8_t pin, int mode, bool preset, int status) = 0;
     virtual void GPIOdigitalWrite(uint8_t pin, int status) = 0;
     virtual bool GPIOdigitalRead(uint8_t pin) = 0;
@@ -23,7 +25,8 @@ enum OPENKNX_GPIO_T
 {
   OPENKNX_GPIO_T_MCU = 0,
   OPENKNX_GPIO_T_TCA9555 = 1,
-  OPENKNX_GPIO_T_TCA6408 = 2
+  OPENKNX_GPIO_T_TCA6408 = 2, 
+  OPENKNX_GPIO_T_PCA9557 = 3
 };
 
 
@@ -42,9 +45,7 @@ class GPIOModule : public OpenKNX::Module
     void pinMode(uint16_t pin, int mode, bool preset=false, int status=0);
     void digitalWrite(uint16_t pin, int status);
     bool digitalRead(uint16_t pin);
-
-  private:
-
+    const bool initialized(uint8_t expander);
 };
 
 extern GPIOModule openknxGPIOModule;

--- a/src/GPIOModule.h
+++ b/src/GPIOModule.h
@@ -1,3 +1,4 @@
+#ifdef USE_GPIO_MODULE
 #pragma once
 #include "OpenKNX.h"
 #include "hardware.h"
@@ -49,3 +50,5 @@ class GPIOModule : public OpenKNX::Module
 };
 
 extern GPIOModule openknxGPIOModule;
+
+#endif // USE_GPIO_MODULE

--- a/src/GPIO_MCU.cpp
+++ b/src/GPIO_MCU.cpp
@@ -1,3 +1,4 @@
+#ifdef USE_GPIO_MODULE
 #include "GPIO_MCU.h"
 #include "Arduino.h"
 
@@ -12,9 +13,19 @@ int GPIO_MCU::init()
 
 void GPIO_MCU::GPIOpinMode(uint8_t pin, int mode, bool preset, int status)
 {
-    if(preset)
+    pinMode(pin, mode); // Erst den Modus setzen!
+
+    if (preset)
+    {
+#ifdef ARDUINO_ARCH_ESP32
+        if (status)
+            gpio_set_level((gpio_num_t)pin, HIGH); // Setze Pin HIGH
+        else
+            gpio_set_level((gpio_num_t)pin, LOW); // Setze Pin LOW
+#else
         digitalWriteFast(pin, status);
-    pinMode(pin, mode);
+#endif
+    }
 }
 
 void GPIO_MCU::GPIOdigitalWrite(uint8_t pin, int status)
@@ -26,3 +37,4 @@ bool GPIO_MCU::GPIOdigitalRead(uint8_t pin)
 {
     return digitalRead(pin);
 }
+#endif // USE_GPIO_MODULE

--- a/src/GPIO_MCU.h
+++ b/src/GPIO_MCU.h
@@ -1,3 +1,4 @@
+#ifdef USE_GPIO_MODULE
 #include "GPIOModule.h"
 
 class GPIO_MCU : public iGPIOExpander
@@ -13,3 +14,4 @@ class GPIO_MCU : public iGPIOExpander
   private:
     bool _initialized = false;
 };
+#endif // USE_GPIO_MODULE

--- a/src/GPIO_PCA9557.cpp
+++ b/src/GPIO_PCA9557.cpp
@@ -1,9 +1,8 @@
 #include "GPIO_PCA9557.h"
 
 GPIO_PCA9557::GPIO_PCA9557(uint8_t i2cAddr, TwoWire* wire)
-    : _i2cAddr(i2cAddr), _wire(wire)
 {
-    _pca = new SFE_PCA95XX();
+    _pca = new PCA95XX(wire, i2cAddr, PCA95XX_PCA9557);
 }
 
 GPIO_PCA9557::~GPIO_PCA9557()
@@ -13,7 +12,7 @@ GPIO_PCA9557::~GPIO_PCA9557()
 
 int GPIO_PCA9557::init()
 {
-    if (_pca->begin(_i2cAddr, *_wire))
+    if (_pca->begin())
     {
         return 0;
     }

--- a/src/GPIO_PCA9557.cpp
+++ b/src/GPIO_PCA9557.cpp
@@ -1,0 +1,65 @@
+#include "GPIO_PCA9557.h"
+
+GPIO_PCA9557::GPIO_PCA9557(uint8_t i2cAddr, TwoWire* wire)
+    : _i2cAddr(i2cAddr), _wire(wire)
+{
+    _pca = new SFE_PCA95XX();
+}
+
+GPIO_PCA9557::~GPIO_PCA9557()
+{
+    delete _pca;
+}
+
+int GPIO_PCA9557::init()
+{
+    if (_pca->begin(_i2cAddr, *_wire))
+    {
+        return 0;
+    }
+    else
+    {
+        return -1;
+    }
+}
+
+void GPIO_PCA9557::GPIOpinMode(uint8_t pin, int mode, bool preset, int status)
+{
+    if (pin > 7 || (mode != INPUT && mode != OUTPUT))
+    {
+        return;
+    }
+
+    if (preset)
+    {
+        _pca->digitalWrite(pin, status);
+    }
+
+    if (mode == INPUT)
+    {
+        _pca->pinMode(pin, INPUT);
+    }
+    else
+    {
+        _pca->pinMode(pin, OUTPUT);
+    }
+}
+
+// Writes a digital value (HIGH/LOW) to the specified pin
+void GPIO_PCA9557::GPIOdigitalWrite(uint8_t pin, int status)
+{
+    if (pin > 7)
+    {
+        return;
+    }
+    _pca->digitalWrite(pin, status);
+}
+
+bool GPIO_PCA9557::GPIOdigitalRead(uint8_t pin)
+{
+    if (pin > 7)
+    {
+        return false;
+    }
+    return _pca->digitalRead(pin);
+}

--- a/src/GPIO_PCA9557.cpp
+++ b/src/GPIO_PCA9557.cpp
@@ -1,3 +1,4 @@
+#ifdef USE_GPIO_MODULE
 #include "GPIO_PCA9557.h"
 
 GPIO_PCA9557::GPIO_PCA9557(uint8_t i2cAddr, TwoWire* wire)
@@ -62,3 +63,4 @@ bool GPIO_PCA9557::GPIOdigitalRead(uint8_t pin)
     }
     return _pca->digitalRead(pin);
 }
+#endif // USE_GPIO_MODULE

--- a/src/GPIO_PCA9557.h
+++ b/src/GPIO_PCA9557.h
@@ -1,14 +1,11 @@
 #pragma once
-
-#include <SparkFun_I2C_Expander_Arduino_Library.h> // Using SparkFun library for PCA9557
+#include "PCA95xx.h"
 #include "GPIOModule.h"
 
 class GPIO_PCA9557 : public iGPIOExpander
 {
   private:
-    SFE_PCA95XX* _pca = nullptr;
-    uint8_t _i2cAddr;
-    TwoWire* _wire;
+    PCA95XX* _pca = nullptr;
     bool _initialized = false;
 
   public:

--- a/src/GPIO_PCA9557.h
+++ b/src/GPIO_PCA9557.h
@@ -1,15 +1,23 @@
+#pragma once
+
+#include <SparkFun_I2C_Expander_Arduino_Library.h> // Using SparkFun library for PCA9557
 #include "GPIOModule.h"
 
-class GPIO_MCU : public iGPIOExpander
+class GPIO_PCA9557 : public iGPIOExpander
 {
+  private:
+    SFE_PCA95XX* _pca = nullptr;
+    uint8_t _i2cAddr;
+    TwoWire* _wire;
+    bool _initialized = false;
+
   public:
-    GPIO_MCU();
+    GPIO_PCA9557(uint8_t i2cAddr, TwoWire* wire);
+    virtual ~GPIO_PCA9557();
     virtual int init() override;
     virtual void GPIOpinMode(uint8_t pin, int mode, bool preset, int status) override;
     virtual void GPIOdigitalWrite(uint8_t pin, int status) override;
     virtual bool GPIOdigitalRead(uint8_t pin) override;
     virtual inline const bool getInitState() { return _initialized; }
     virtual inline void setInitState(const bool status) { _initialized = status; }
-  private:
-    bool _initialized = false;
 };

--- a/src/GPIO_PCA9557.h
+++ b/src/GPIO_PCA9557.h
@@ -1,3 +1,4 @@
+#ifdef USE_GPIO_MODULE
 #pragma once
 #include "PCA95xx.h"
 #include "GPIOModule.h"
@@ -18,3 +19,4 @@ class GPIO_PCA9557 : public iGPIOExpander
     virtual inline const bool getInitState() { return _initialized; }
     virtual inline void setInitState(const bool status) { _initialized = status; }
 };
+#endif // USE_GPIO_MODULE

--- a/src/GPIO_TCA6408.cpp
+++ b/src/GPIO_TCA6408.cpp
@@ -1,3 +1,4 @@
+#ifdef USE_GPIO_MODULE
 #include "GPIO_TCA6408.h"
 
 GPIO_TCA6408::GPIO_TCA6408(uint16_t i2cAddr, TwoWire* wire)
@@ -52,3 +53,4 @@ bool GPIO_TCA6408::GPIOdigitalRead(uint8_t pin)
     }
     return _tca->read1(pin);
 }
+#endif // USE_GPIO_MODULE

--- a/src/GPIO_TCA6408.h
+++ b/src/GPIO_TCA6408.h
@@ -5,10 +5,13 @@ class GPIO_TCA6408 : public iGPIOExpander
 {
   private:
     TCA6408* _tca = nullptr;
+    bool _initialized = false;
   public:
     GPIO_TCA6408(uint16_t i2cAddr, TwoWire* wire);
     virtual int init() override;
     virtual void GPIOpinMode(uint8_t pin, int mode, bool preset, int status) override;
     virtual void GPIOdigitalWrite(uint8_t pin, int status) override;
     virtual bool GPIOdigitalRead(uint8_t pin) override;
+    virtual inline const bool getInitState() { return _initialized; }
+    virtual inline void setInitState(const bool status) { _initialized = status; }
 };

--- a/src/GPIO_TCA6408.h
+++ b/src/GPIO_TCA6408.h
@@ -1,3 +1,4 @@
+#ifdef USE_GPIO_MODULE
 #include "GPIOModule.h"
 #include "TCA6408.h"
 
@@ -15,3 +16,4 @@ class GPIO_TCA6408 : public iGPIOExpander
     virtual inline const bool getInitState() { return _initialized; }
     virtual inline void setInitState(const bool status) { _initialized = status; }
 };
+#endif // USE_GPIO_MODULE

--- a/src/GPIO_TCA9555.cpp
+++ b/src/GPIO_TCA9555.cpp
@@ -1,3 +1,4 @@
+#ifdef USE_GPIO_MODULE
 #include "GPIO_TCA9555.h"
 
 GPIO_TCA9555::GPIO_TCA9555(uint16_t i2cAddr, TwoWire* wire)
@@ -52,3 +53,4 @@ bool GPIO_TCA9555::GPIOdigitalRead(uint8_t pin)
     }
     return _tca->read1(pin);
 }
+#endif // USE_GPIO_MODULE

--- a/src/GPIO_TCA9555.h
+++ b/src/GPIO_TCA9555.h
@@ -5,10 +5,13 @@ class GPIO_TCA9555 : public iGPIOExpander
 {
   private:
     TCA9555* _tca = nullptr;
+    bool _initialized = false;
   public:
     GPIO_TCA9555(uint16_t i2cAddr, TwoWire* wire);
     virtual int init() override;
     virtual void GPIOpinMode(uint8_t pin, int mode, bool preset, int status) override;
     virtual void GPIOdigitalWrite(uint8_t pin, int status) override;
     virtual bool GPIOdigitalRead(uint8_t pin) override;
+    virtual inline const bool getInitState() { return _initialized; }
+    virtual inline void setInitState(const bool status) { _initialized = status; }
 };

--- a/src/GPIO_TCA9555.h
+++ b/src/GPIO_TCA9555.h
@@ -1,3 +1,4 @@
+#ifdef USE_GPIO_MODULE
 #include "GPIOModule.h"
 #include "TCA9555.h"
 
@@ -15,3 +16,4 @@ class GPIO_TCA9555 : public iGPIOExpander
     virtual inline const bool getInitState() { return _initialized; }
     virtual inline void setInitState(const bool status) { _initialized = status; }
 };
+#endif // USE_GPIO_MODULE

--- a/src/PCA95xx.cpp
+++ b/src/PCA95xx.cpp
@@ -1,5 +1,5 @@
 /**
- * OpenKNX I2C I/O Expander Library for PCA95xx series
+ * OpenKNX I2C I/O Expander Library for NXP PCA95xx series
  *
  * Based on the original SparkFun I2C Expander Arduino Library
  * (https://github.com/sparkfunX/SparkFun_I2C_Expander_Arduino_Library)

--- a/src/PCA95xx.cpp
+++ b/src/PCA95xx.cpp
@@ -1,0 +1,282 @@
+/**
+ * OpenKNX I2C I/O Expander Library for PCA95xx series
+ *
+ * Based on the original SparkFun I2C Expander Arduino Library
+ * (https://github.com/sparkfunX/SparkFun_I2C_Expander_Arduino_Library)
+ *
+ * Supports PCA/TCA series I/O expanders:
+ * - PCA9534/TCA9534: 8-bit with INT
+ * - PCA9536/TCA9536: 4-bit with optional INT
+ * - PCA9537/TCA9537: 4-bit with INT/RST
+ * - PCA9554/TCA9554: 8-bit with INT
+ * - PCA9556/TCA9556: 8-bit with RST
+ * - PCA9557/TCA9557: 8-bit with RST
+ *
+ * Modified by Erkan Çolar 2024
+ * Original work by SparkFun Electronics (2018-2024)
+ *
+ * License: GNU General Public License
+ */
+
+#include "PCA95xx.h"
+
+// Constructor
+PCA95XX::PCA95XX( TwoWire *wirePort, uint8_t address, pca95xx_devices_e device, uint8_t numberOfGpio)
+{
+    _i2cPort = wirePort;
+    
+    switch (device)
+    {
+        default: // Default is the PCA9554
+            _deviceAddress = ( address != 255 ) ? (PCA95XX_Address_t)address : PCA9554_ADDRESS_20;
+            _numberOfGpio = (numberOfGpio != 255) ? numberOfGpio : 8;
+            _deviceType = PCA95XX_PCA9554;
+            break;
+
+        case PCA95XX_PCA9534:
+            _deviceAddress = ( address != 255 ) ? (PCA95XX_Address_t)address : PCA9534_ADDRESS_20;
+            _numberOfGpio = (numberOfGpio != 255) ? numberOfGpio : 8;
+            _deviceType = PCA95XX_PCA9534;
+            break;
+
+        case PCA95XX_PCA9536:
+            _deviceAddress = ( address != 255 ) ? (PCA95XX_Address_t)address : PCA9536_ADDRESS;
+            _numberOfGpio = (numberOfGpio != 255) ? numberOfGpio : 4;
+            _deviceType = PCA95XX_PCA9536;
+            break;
+
+        case PCA95XX_PCA9537:
+            _deviceAddress = ( address != 255 ) ? (PCA95XX_Address_t)address : PCA9537_ADDRESS;
+            _numberOfGpio = (numberOfGpio != 255) ? numberOfGpio : 4;
+            _deviceType = PCA95XX_PCA9537;
+            break;
+
+        case PCA95XX_PCA9554:
+            _deviceAddress = ( address != 255 ) ? (PCA95XX_Address_t)address : PCA9554_ADDRESS_20;
+            _numberOfGpio = (numberOfGpio != 255) ? numberOfGpio : 8;
+            _deviceType = PCA95XX_PCA9554;
+            break;
+
+        case PCA95XX_PCA9556:
+            _deviceAddress = ( address != 255 ) ? (PCA95XX_Address_t)address : PCA9556_ADDRESS_18;
+            _numberOfGpio = (numberOfGpio != 255) ? numberOfGpio : 8;
+            _deviceType = PCA95XX_PCA9556;
+            break;
+
+        case PCA95XX_PCA9557:
+            _deviceAddress = ( address != 255 ) ? (PCA95XX_Address_t)address : PCA9557_ADDRESS_18;
+            _numberOfGpio = (numberOfGpio != 255) ? numberOfGpio : 8;
+            _deviceType = PCA95XX_PCA9557;
+            break;
+    }
+}
+
+bool PCA95XX::begin()
+{
+    return (isConnected());
+}
+
+bool PCA95XX::isConnected(void)
+{
+    _i2cPort->beginTransmission((uint8_t)_deviceAddress);
+    return (_i2cPort->endTransmission() == 0);
+}
+
+PCA95XX_error_t PCA95XX::pinMode(uint8_t pin, uint8_t mode)
+{
+    PCA95XX_error_t err;
+    uint8_t cfgRegister = 0;
+
+    if (pin >= _numberOfGpio)
+        return PCA95XX_ERROR_UNDEFINED;
+
+    err = readI2CRegister(&cfgRegister, PCA95XX_REGISTER_CONFIGURATION);
+    if (err != PCA95XX_ERROR_SUCCESS)
+    {
+        return err;
+    }
+    cfgRegister &= ~(1 << pin);
+    if (mode == INPUT)
+    {
+        cfgRegister |= (1 << pin);
+    }
+    return writeI2CRegister(cfgRegister, PCA95XX_REGISTER_CONFIGURATION);
+}
+
+// Safe writing of a pin
+PCA95XX_error_t PCA95XX::write(uint8_t pin, uint8_t value)
+{
+    if (pin >= _numberOfGpio)
+        return PCA95XX_ERROR_UNDEFINED;
+
+    uint8_t outputRegister;
+    PCA95XX_error_t err = readI2CRegister(&outputRegister, PCA95XX_REGISTER_OUTPUT_PORT);
+    if (err != PCA95XX_ERROR_SUCCESS)
+        return err;
+
+    const uint8_t mask = 1 << pin;
+    outputRegister = (outputRegister & ~mask) | ((value != 0) << pin);
+
+    return writeI2CRegister(outputRegister, PCA95XX_REGISTER_OUTPUT_PORT);
+}
+
+// digitalWrite overload 
+PCA95XX_error_t PCA95XX::digitalWrite(uint8_t pin, uint8_t value)
+{
+    return write(pin, value);
+}
+
+// Safe reading of input register
+PCA95XX_error_t PCA95XX::getInputRegister(uint8_t *destination)
+{
+    PCA95XX_error_t err;
+    uint8_t inputRegister = 0;
+
+    err = readI2CRegister(&inputRegister, PCA95XX_REGISTER_INPUT_PORT);
+    if (err != PCA95XX_ERROR_SUCCESS)
+        return err;
+
+    *destination = inputRegister;
+    return (err);
+}
+
+// Unsafe overload
+uint8_t PCA95XX::getInputRegister()
+{
+    uint8_t val;
+    if (getInputRegister(&val) == PCA95XX_ERROR_SUCCESS)
+        return val;
+    return 0; // Unsafe
+}
+
+// Safe reading of a pin
+PCA95XX_error_t PCA95XX::read(uint8_t *destination, uint8_t pin)
+{
+    PCA95XX_error_t err;
+    uint8_t inputRegister = 0;
+
+    if (pin >= _numberOfGpio)
+        return PCA95XX_ERROR_UNDEFINED;
+
+    err = readI2CRegister(&inputRegister, PCA95XX_REGISTER_INPUT_PORT);
+    if (err != PCA95XX_ERROR_SUCCESS)
+        return err;
+
+    *destination = (inputRegister & (1 << pin)) >> pin;
+    return (err);
+}
+
+// Unsafe overload
+uint8_t PCA95XX::read(uint8_t pin)
+{
+    uint8_t val;
+    if (read(&val, pin) == PCA95XX_ERROR_SUCCESS)
+        return val;
+    return 0; // Unsafe
+}
+
+// Safe reading of a pin
+PCA95XX_error_t PCA95XX::digitalRead(uint8_t *destination, uint8_t pin)
+{
+    return (read(destination, pin));
+}
+
+// Unsafe overload
+uint8_t PCA95XX::digitalRead(uint8_t pin)
+{
+    uint8_t val;
+    if (digitalRead(&val, pin) == PCA95XX_ERROR_SUCCESS)
+        return val;
+    return 0; // Unsafe
+}
+
+// Invert the polarity of a pin
+PCA95XX_error_t PCA95XX::invert(uint8_t pin, PCA95XX_invert_t inversion)
+{
+    if (pin >= _numberOfGpio)
+        return PCA95XX_ERROR_UNDEFINED;
+    
+    uint8_t invertRegister;
+    PCA95XX_error_t err = readI2CRegister(&invertRegister, PCA95XX_REGISTER_POLARITY_INVERSION);
+    if (err != PCA95XX_ERROR_SUCCESS)
+        return err;
+
+    const uint8_t mask = 1 << pin;
+    invertRegister = (invertRegister & ~mask) | ((inversion == PCA95XX_INVERT) << pin);
+
+    return writeI2CRegister(invertRegister, PCA95XX_REGISTER_POLARITY_INVERSION);
+}
+
+// Revert the polarity of a pin
+PCA95XX_error_t PCA95XX::revert(uint8_t pin)
+{
+    return invert(pin, PCA95XX_RETAIN);
+}
+
+// Private functions
+PCA95XX_error_t PCA95XX::readI2CBuffer(uint8_t *dest, PCA95XX_REGISTER_t startRegister, uint16_t len)
+{
+    if (_deviceAddress == PCA95XX_ADDRESS_INVALID)
+    {
+        return PCA95XX_ERROR_INVALID_ADDRESS;
+    }
+    _i2cPort->beginTransmission((uint8_t)_deviceAddress);
+    _i2cPort->write(startRegister);
+    if (_i2cPort->endTransmission(false) != 0)
+    {
+        return PCA95XX_ERROR_READ;
+    }
+
+    _i2cPort->requestFrom((uint8_t)_deviceAddress, (uint8_t)len);
+    for (int i = 0; i < len; i++)
+    {
+        dest[i] = _i2cPort->read();
+    }
+
+    return PCA95XX_ERROR_SUCCESS;
+}
+
+PCA95XX_error_t PCA95XX::writeI2CBuffer(uint8_t *src, PCA95XX_REGISTER_t startRegister, uint16_t len)
+{
+    if (_deviceAddress == PCA95XX_ADDRESS_INVALID)
+    {
+        return PCA95XX_ERROR_INVALID_ADDRESS;
+    }
+    _i2cPort->beginTransmission((uint8_t)_deviceAddress);
+    _i2cPort->write(startRegister);
+    for (int i = 0; i < len; i++)
+    {
+        _i2cPort->write(src[i]);
+    }
+    if (_i2cPort->endTransmission(true) != 0)
+    {
+        return PCA95XX_ERROR_WRITE;
+    }
+    return PCA95XX_ERROR_SUCCESS;
+}
+
+PCA95XX_error_t PCA95XX::readI2CRegister(uint8_t *dest, PCA95XX_REGISTER_t registerAddress)
+{
+    PCA95XX_error_t result = readI2CBuffer(dest, registerAddress, 1);
+
+    // Interrupt Errata: User must change command byte to something besides 00h after a Read operation
+    if (_deviceType == PCA95XX_PCA9554 && registerAddress == PCA95XX_REGISTER_INPUT_PORT)
+    {
+        // If we've just read the INPUT Port register, we must change command byte
+        writeI2CBuffer(0, PCA95XX_REGISTER_OUTPUT_PORT, 0); // Write the command register, but no data
+    }
+    return result;
+}
+
+PCA95XX_error_t PCA95XX::writeI2CRegister(uint8_t data, PCA95XX_REGISTER_t registerAddress)
+{
+    PCA95XX_error_t result = writeI2CBuffer(&data, registerAddress, 1);
+
+    // Interrupt Errata: User must change command byte to something besides 00h after a Read operation
+    if (_deviceType == PCA95XX_PCA9554 && registerAddress == PCA95XX_REGISTER_INPUT_PORT)
+    {
+        // If we've just read the INPUT Port register, we must change command byte
+        writeI2CBuffer(0, PCA95XX_REGISTER_OUTPUT_PORT, 0); // Write the command register, but no data
+    }
+    return result;
+}

--- a/src/PCA95xx.h
+++ b/src/PCA95xx.h
@@ -1,0 +1,134 @@
+#pragma once
+#include "Arduino.h"
+#include <Wire.h>
+
+// Supported PCA variants
+typedef enum
+{
+    PCA95XX_PCA9534,
+    PCA95XX_PCA9536,
+    PCA95XX_PCA9537,
+    PCA95XX_PCA9554,
+    PCA95XX_PCA9556,
+    PCA95XX_PCA9557,
+} pca95xx_devices_e;
+
+// Valid PCA95XX addresses
+typedef enum
+{
+    PCA9534_ADDRESS_20 = 0x20,
+    PCA9534_ADDRESS_21 = 0x21,
+    PCA9534_ADDRESS_22 = 0x22,
+    PCA9534_ADDRESS_23 = 0x23,
+    PCA9534_ADDRESS_24 = 0x24,
+    PCA9534_ADDRESS_25 = 0x25,
+    PCA9534_ADDRESS_26 = 0x26,
+    PCA9534_ADDRESS_27 = 0x27,
+
+    PCA9536_ADDRESS = 0x41,
+
+    PCA9537_ADDRESS = 0x49,
+
+    PCA9554_ADDRESS_20 = 0x20,
+    PCA9554_ADDRESS_21 = 0x21,
+    PCA9554_ADDRESS_22 = 0x22,
+    PCA9554_ADDRESS_23 = 0x23,
+    PCA9554_ADDRESS_24 = 0x24,
+    PCA9554_ADDRESS_25 = 0x25,
+    PCA9554_ADDRESS_26 = 0x26,
+    PCA9554_ADDRESS_27 = 0x27,
+
+    PCA9556_ADDRESS_18 = 0x18,
+    PCA9556_ADDRESS_19 = 0x19,
+    PCA9556_ADDRESS_1A = 0x1A,
+    PCA9556_ADDRESS_1B = 0x1B,
+    PCA9556_ADDRESS_1C = 0x1C,
+    PCA9556_ADDRESS_1D = 0x1D,
+    PCA9556_ADDRESS_1E = 0x1E,
+    PCA9556_ADDRESS_1F = 0x1F,
+
+    PCA9557_ADDRESS_18 = 0x18,
+    PCA9557_ADDRESS_19 = 0x19,
+    PCA9557_ADDRESS_1A = 0x1A,
+    PCA9557_ADDRESS_1B = 0x1B,
+    PCA9557_ADDRESS_1C = 0x1C,
+    PCA9557_ADDRESS_1D = 0x1D,
+    PCA9557_ADDRESS_1E = 0x1E,
+    PCA9557_ADDRESS_1F = 0x1F,
+
+    PCA95XX_ADDRESS_INVALID = 0xFF
+} PCA95XX_Address_t;
+
+// PCA95XX registers:
+typedef enum
+{
+    PCA95XX_REGISTER_INPUT_PORT = 0x00,
+    PCA95XX_REGISTER_OUTPUT_PORT = 0x01,
+    PCA95XX_REGISTER_POLARITY_INVERSION = 0x02,
+    PCA95XX_REGISTER_CONFIGURATION = 0x03,
+    PCA95XX_REGISTER_INVALID
+} PCA95XX_REGISTER_t;
+
+// PCA95XX error code returns:
+typedef enum
+{
+    PCA95XX_ERROR_READ = -4,
+    PCA95XX_ERROR_WRITE = -3,
+    PCA95XX_ERROR_INVALID_ADDRESS = -2,
+    PCA95XX_ERROR_UNDEFINED = -1,
+    PCA95XX_ERROR_SUCCESS = 1
+} PCA95XX_error_t;
+const PCA95XX_error_t PCA95XX_SUCCESS = PCA95XX_ERROR_SUCCESS;
+
+// PCA95XX invert/normal values:
+typedef enum
+{
+    PCA95XX_RETAIN,    // 0
+    PCA95XX_INVERT,    // 1
+    PCA95XX_INVERT_END // 2
+} PCA95XX_invert_t;
+
+class PCA95XX
+{
+  public:
+    PCA95XX(TwoWire *wirePort = nullptr, uint8_t address = 255,
+            pca95xx_devices_e device = PCA95XX_PCA9554,
+            uint8_t numberOfGpio = 255);
+
+    bool begin();
+    bool isConnected();
+
+    // pinMode can set a pin (0-3) to INPUT or OUTPUT
+    PCA95XX_error_t pinMode(uint8_t pin, uint8_t mode);
+
+    // digitalWrite and write can be used to set a pin HIGH or LOW
+    PCA95XX_error_t digitalWrite(uint8_t pin, uint8_t value);
+    PCA95XX_error_t write(uint8_t pin, uint8_t value);
+
+    // getInputRegister can be used to read the whole input register
+    PCA95XX_error_t getInputRegister(uint8_t *destination); // Returns error if problem
+    uint8_t getInputRegister();                             // May return erroneous data if read fails
+
+    // read and digitalRead can be used to read a pin
+    PCA95XX_error_t read(uint8_t *destination, uint8_t pin);
+    uint8_t read(uint8_t pin); // May return erroneous data if read fails
+
+    PCA95XX_error_t digitalRead(uint8_t *destination, uint8_t pin);
+    uint8_t digitalRead(uint8_t pin); // May return erroneous data if read fails
+
+    // invert and revert can be used to invert (or not) the I/O logic during a read
+    PCA95XX_error_t invert(uint8_t pin, PCA95XX_invert_t inversion = PCA95XX_INVERT);
+    PCA95XX_error_t revert(uint8_t pin);
+
+  private:
+    TwoWire *_i2cPort;                // The generic connection to user's chosen I2C hardware
+    PCA95XX_Address_t _deviceAddress; // The I2C address of the PCA95XX
+    pca95xx_devices_e _deviceType;    // The type of PCA95XX
+    byte _numberOfGpio;               // The number of GPIO pins on the PCA95XX
+
+    // I2C Read/Write
+    PCA95XX_error_t readI2CBuffer(uint8_t *dest, PCA95XX_REGISTER_t startRegister, uint16_t len);
+    PCA95XX_error_t writeI2CBuffer(uint8_t *src, PCA95XX_REGISTER_t startRegister, uint16_t len);
+    PCA95XX_error_t readI2CRegister(uint8_t *dest, PCA95XX_REGISTER_t registerAddress);
+    PCA95XX_error_t writeI2CRegister(uint8_t data, PCA95XX_REGISTER_t registerAddress);
+};


### PR DESCRIPTION
Expand iGPIOExpander & GPIOModule class to set and get the initialized state of the expanders.